### PR TITLE
Adds support for 'Redshift' shredding format

### DIFF
--- a/snowplow_analytics_sdk/event_transformer.py
+++ b/snowplow_analytics_sdk/event_transformer.py
@@ -34,7 +34,8 @@ def convert_bool(key, value):
         return [(key, True)]
     elif value == '0':
         return [(key, False)]
-    raise SnowplowEventTransformationException(["Invalid value {} for field {}".format(value, key)])
+    raise SnowplowEventTransformationException(
+        ["Invalid value {} for field {}".format(value, key)])
 
 
 def convert_double(key, value):
@@ -196,19 +197,22 @@ def transform(line, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_dat
     return jsonify_good_event(line.split('\t'), known_fields, add_geolocation_data, shred_format)
 
 
-def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, shred_format='elasticsearch'):
+def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True,
+                       shred_format='elasticsearch'):
     """
     Convert a Snowplow enriched event in the form of an array of fields into a JSON
     """
     if len(event) != len(known_fields):
         raise SnowplowEventTransformationException(
-            ["Expected {} fields, received {} fields.".format(len(known_fields), len(event))]
+            ["Expected {} fields, received {} fields.".format(
+                len(known_fields), len(event))]
         )
     else:
         output = {}
         errors = []
         if add_geolocation_data and event[LATITUDE_INDEX] != '' and event[LONGITUDE_INDEX] != '':
-            output['geo_location'] = event[LATITUDE_INDEX] + ',' + event[LONGITUDE_INDEX]
+            output['geo_location'] = event[LATITUDE_INDEX] + \
+                ',' + event[LONGITUDE_INDEX]
         for i in range(len(event)):
             key = known_fields[i][0]
             if event[i] != '':

--- a/snowplow_analytics_sdk/event_transformer.py
+++ b/snowplow_analytics_sdk/event_transformer.py
@@ -45,12 +45,12 @@ def convert_tstamp(key, value):
     return [(key, value.replace(' ', 'T') + 'Z')]
 
 
-def convert_contexts(key, value, add_schema_contexts=False):
-    return json_shredder.parse_contexts(value, add_schema_contexts)
+def convert_contexts(key, value, shred_format='elasticsearch'):
+    return json_shredder.parse_contexts(value, shred_format)
 
 
-def convert_unstruct(key, value, add_schema=False):
-    return json_shredder.parse_unstruct(value, add_schema)
+def convert_unstruct(key, value, shred_format='elasticsearch'):
+    return json_shredder.parse_unstruct(value, shred_format)
 
 
 # Ordered list of names of enriched event fields together with the function required to convert them to JSON
@@ -189,14 +189,14 @@ ENRICHED_EVENT_FIELD_TYPES = (
 )
 
 
-def transform(line, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, add_schema=False, add_schema_contexts=False):
+def transform(line, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, shred_format='elasticsearch'):
     """
     Convert a Snowplow enriched event TSV into a JSON
     """
-    return jsonify_good_event(line.split('\t'), known_fields, add_geolocation_data, add_schema, add_schema_contexts)
+    return jsonify_good_event(line.split('\t'), known_fields, add_geolocation_data, shred_format)
 
 
-def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, add_schema=False, add_schema_contexts=False):
+def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, shred_format='elasticsearch'):
     """
     Convert a Snowplow enriched event in the form of an array of fields into a JSON
     """
@@ -216,9 +216,9 @@ def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolo
                     field = known_fields[i][0]
                     function = known_fields[i][1]
                     if field == 'unstruct_event':
-                        kvpairs = function(key, event[i], add_schema)
+                        kvpairs = function(key, event[i], shred_format)
                     elif field == 'contexts' or field == 'derived_contexts':
-                        kvpairs = function(key, event[i], add_schema_contexts)
+                        kvpairs = function(key, event[i], shred_format)
                     else:
                         kvpairs = function(key, event[i])
                     for kvpair in kvpairs:

--- a/snowplow_analytics_sdk/json_shredder.py
+++ b/snowplow_analytics_sdk/json_shredder.py
@@ -63,9 +63,10 @@ def fix_schema(prefix, schema):
     vendor, name, format, version = parse_schema(schema, underscore_vendor=True)
     model = version.split('-')[0]
     if prefix != "":
-      return "{}_{}_{}_{}".format(prefix, vendor, name, model)
+        return "{}_{}_{}_{}".format(prefix, vendor, name, model)
     else:
-      return "{}_{}_{}".format(vendor, name, model)
+        return "{}_{}_{}".format(vendor, name, model)
+
 
 def parse_schema(schema, underscore_vendor=True):
     """
@@ -73,13 +74,14 @@ def parse_schema(schema, underscore_vendor=True):
     """
     schema_dict = extract_schema(schema)
     if underscore_vendor:
-      vendor = schema_dict['vendor'].replace('.', '_').lower()
+        vendor = schema_dict['vendor'].replace('.', '_').lower()
     else:
-      vendor = schema_dict['vendor'].lower()
+        vendor = schema_dict['vendor'].lower()
     name = re.sub('([^A-Z_])([A-Z])', '\g<1>_\g<2>', schema_dict['name']).lower()
     format = schema_dict.get('format')
     version = schema_dict['version']
     return vendor, name, format, version
+
 
 def parse_contexts(contexts, shred_format='elasticsearch'):
     """
@@ -183,11 +185,11 @@ def parse_unstruct(unstruct, shred_format='elasticsearch'):
     data = my_json['data']
     schema = data['schema']
     if 'data' in data:
-        if include_data:
-          inner_data = {}
-          inner_data['data'] = data['data']
+        if shred_format == 'redshift':
+            inner_data = {}
+            inner_data['data'] = data['data']
         else:
-          inner_data = data['data']
+            inner_data = data['data']
     else:
         raise SnowplowEventTransformationException(["Could not extract inner data field from unstructured event"])
 

--- a/tests/test_event_transformer.py
+++ b/tests/test_event_transformer.py
@@ -1,5 +1,5 @@
 """
-    Copyright (c) 2016 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2016-2017 Snowplow Analytics Ltd. All rights reserved.
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
     Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
@@ -10,7 +10,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
     Authors: Fred Blundun
-    Copyright: Copyright (c) 2016 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2016-2017 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/tests/test_event_transformer_with_schema.py
+++ b/tests/test_event_transformer_with_schema.py
@@ -15,7 +15,6 @@
 """
 
 from snowplow_analytics_sdk.event_transformer import transform
-from snowplow_analytics_sdk.snowplow_event_transformation_exception import SnowplowEventTransformationException
 import json
 
 unstruct_json = """{
@@ -471,11 +470,12 @@ expected2 = json.loads("""{
         "true_tstamp": "2013-11-26T00:03:57.886Z"
       }""")
 
+
 def test_transform_with_elasticsearch_format():
     actual = transform(tsv, shred_format='elasticsearch')
     assert(actual == expected)
 
+
 def test_transform_with_redshift_format():
     actual = transform(tsv, shred_format='redshift')
     assert(actual == expected2)
-

--- a/tests/test_event_transformer_with_schema.py
+++ b/tests/test_event_transformer_with_schema.py
@@ -1,0 +1,473 @@
+"""
+    Copyright (c) 2016-2017 Snowplow Analytics Ltd. All rights reserved.
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+    Authors: Fred Blundun, Mike Robins
+    Copyright: Copyright (c) 2016-2017 Snowplow Analytics Ltd
+    License: Apache License Version 2.0
+"""
+
+from snowplow_analytics_sdk.event_transformer import transform
+from snowplow_analytics_sdk.snowplow_event_transformation_exception import SnowplowEventTransformationException
+import json
+
+unstruct_json = """{
+    "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+    "data": {
+      "schema": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+      "data": {
+        "targetUrl": "http://www.example.com",
+        "elementClasses": ["foreground"],
+        "elementId": "exampleLink"
+      }
+    }
+  }"""
+
+contexts_json = """{
+    "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+    "data": [
+      {
+        "schema": "iglu:org.schema/WebPage/jsonschema/1-0-0",
+        "data": {
+          "genre": "blog",
+          "inLanguage": "en-US",
+          "datePublished": "2014-11-06T00:00:00Z",
+          "author": "Fred Blundun",
+          "breadcrumb": [
+            "blog",
+            "releases"
+          ],
+          "keywords": [
+            "snowplow",
+            "javascript",
+            "tracker",
+            "event"
+          ]
+        }
+      },
+      {
+        "schema": "iglu:org.w3/PerformanceTiming/jsonschema/1-0-0",
+        "data": {
+          "navigationStart": 1415358089861,
+          "unloadEventStart": 1415358090270,
+          "unloadEventEnd": 1415358090287,
+          "redirectStart": 0,
+          "redirectEnd": 0,
+          "fetchStart": 1415358089870,
+          "domainLookupStart": 1415358090102,
+          "domainLookupEnd": 1415358090102,
+          "connectStart": 1415358090103,
+          "connectEnd": 1415358090183,
+          "requestStart": 1415358090183,
+          "responseStart": 1415358090265,
+          "responseEnd": 1415358090265,
+          "domLoading": 1415358090270,
+          "domInteractive": 1415358090886,
+          "domContentLoadedEventStart": 1415358090968,
+          "domContentLoadedEventEnd": 1415358091309,
+          "domComplete": 0,
+          "loadEventStart": 0,
+          "loadEventEnd": 0
+        }
+      }
+    ]
+  }"""
+
+derived_contexts_json = """{
+    "schema": "iglu:com.snowplowanalytics.snowplow\/contexts\/jsonschema\/1-0-1",
+    "data": [
+      {
+        "schema": "iglu:com.snowplowanalytics.snowplow\/ua_parser_context\/jsonschema\/1-0-0",
+        "data": {
+          "useragentFamily": "IE",
+          "useragentMajor": "7",
+          "useragentMinor": "0",
+          "useragentPatch": null,
+          "useragentVersion": "IE 7.0",
+          "osFamily": "Windows XP",
+          "osMajor": null,
+          "osMinor": null,
+          "osPatch": null,
+          "osPatchMinor": null,
+          "osVersion": "Windows XP",
+          "deviceFamily": "Other"
+        }
+      }
+    ]
+  }"""
+
+full_event = (
+        ("app_id", "angry-birds"),
+        ("platform", "web"),
+        ("etl_tstamp", "2017-01-26 00:01:25.292"),
+        ("collector_tstamp", "2013-11-26 00:02:05"),
+        ("dvce_created_tstamp", "2013-11-26 00:03:57.885"),
+        ("event", "page_view"),
+        ("event_id", "c6ef3124-b53a-4b13-a233-0088f79dcbcb"),
+        ("txn_id", "41828"),
+        ("name_tracker", "cloudfront-1"),
+        ("v_tracker", "js-2.1.0"),
+        ("v_collector", "clj-tomcat-0.1.0"),
+        ("v_etl", "serde-0.5.2"),
+        ("user_id", "jon.doe@email.com"),
+        ("user_ipaddress", "92.231.54.234"),
+        ("user_fingerprint", "2161814971"),
+        ("domain_userid", "bc2e92ec6c204a14"),
+        ("domain_sessionidx", "3"),
+        ("network_userid", "ecdff4d0-9175-40ac-a8bb-325c49733607"),
+        ("geo_country", "US"),
+        ("geo_region", "TX"),
+        ("geo_city", "New York"),
+        ("geo_zipcode", "94109"),
+        ("geo_latitude", "37.443604"),
+        ("geo_longitude", "-122.4124"),
+        ("geo_region_name", "Florida"),
+        ("ip_isp", "FDN Communications"),
+        ("ip_organization", "Bouygues Telecom"),
+        ("ip_domain", "nuvox.net"),
+        ("ip_netspeed", "Cable/DSL"),
+        ("page_url", "http://www.snowplowanalytics.com"),
+        ("page_title", "On Analytics"),
+        ("page_referrer", ""),
+        ("page_urlscheme", "http"),
+        ("page_urlhost", "www.snowplowanalytics.com"),
+        ("page_urlport", "80"),
+        ("page_urlpath", "/product/index.html"),
+        ("page_urlquery", "id=GTM-DLRG"),
+        ("page_urlfragment", "4-conclusion"),
+        ("refr_urlscheme", ""),
+        ("refr_urlhost", ""),
+        ("refr_urlport", ""),
+        ("refr_urlpath", ""),
+        ("refr_urlquery", ""),
+        ("refr_urlfragment", ""),
+        ("refr_medium", ""),
+        ("refr_source", ""),
+        ("refr_term", ""),
+        ("mkt_medium", ""),
+        ("mkt_source", ""),
+        ("mkt_term", ""),
+        ("mkt_content", ""),
+        ("mkt_campaign", ""),
+        ("contexts", contexts_json),
+        ("se_category", ""),
+        ("se_action", ""),
+        ("se_label", ""),
+        ("se_property", ""),
+        ("se_value", ""),
+        ("unstruct_event", unstruct_json),
+        ("tr_orderid", ""),
+        ("tr_affiliation", ""),
+        ("tr_total", ""),
+        ("tr_tax", ""),
+        ("tr_shipping", ""),
+        ("tr_city", ""),
+        ("tr_state", ""),
+        ("tr_country", ""),
+        ("ti_orderid", ""),
+        ("ti_sku", ""),
+        ("ti_name", ""),
+        ("ti_category", ""),
+        ("ti_price", ""),
+        ("ti_quantity", ""),
+        ("pp_xoffset_min", ""),
+        ("pp_xoffset_max", ""),
+        ("pp_yoffset_min", ""),
+        ("pp_yoffset_max", ""),
+        ("useragent", ""),
+        ("br_name", ""),
+        ("br_family", ""),
+        ("br_version", ""),
+        ("br_type", ""),
+        ("br_renderengine", ""),
+        ("br_lang", ""),
+        ("br_features_pdf", "1"),
+        ("br_features_flash", "0"),
+        ("br_features_java", ""),
+        ("br_features_director", ""),
+        ("br_features_quicktime", ""),
+        ("br_features_realplayer", ""),
+        ("br_features_windowsmedia", ""),
+        ("br_features_gears", ""),
+        ("br_features_silverlight", ""),
+        ("br_cookies", ""),
+        ("br_colordepth", ""),
+        ("br_viewwidth", ""),
+        ("br_viewheight", ""),
+        ("os_name", ""),
+        ("os_family", ""),
+        ("os_manufacturer", ""),
+        ("os_timezone", ""),
+        ("dvce_type", ""),
+        ("dvce_ismobile", ""),
+        ("dvce_screenwidth", ""),
+        ("dvce_screenheight", ""),
+        ("doc_charset", ""),
+        ("doc_width", ""),
+        ("doc_height", ""),
+        ("tr_currency", ""),
+        ("tr_total_base", ""),
+        ("tr_tax_base", ""),
+        ("tr_shipping_base", ""),
+        ("ti_currency", ""),
+        ("ti_price_base", ""),
+        ("base_currency", ""),
+        ("geo_timezone", ""),
+        ("mkt_clickid", ""),
+        ("mkt_network", ""),
+        ("etl_tags", ""),
+        ("dvce_sent_tstamp", ""),
+        ("refr_domain_userid", ""),
+        ("refr_device_tstamp", ""),
+        ("derived_contexts", derived_contexts_json),
+        ("domain_sessionid", "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1"),
+        ("derived_tstamp", "2013-11-26 00:03:57.886"),
+        ("event_vendor", "com.snowplowanalytics.snowplow"),
+        ("event_name", "link_click"),
+        ("event_format", "jsonschema"),
+        ("event_version", "1-0-0"),
+        ("event_fingerprint", "e3dbfa9cca0412c3d4052863cefb547f"),
+        ("true_tstamp", "2013-11-26 00:03:57.886")
+    )
+
+tsv = '\t'.join(map(lambda x: x[1].replace('\n', ''), full_event))
+
+expected = json.loads("""{
+        "geo_location" : "37.443604,-122.4124",
+        "app_id" : "angry-birds",
+        "platform" : "web",
+        "etl_tstamp" : "2017-01-26T00:01:25.292Z",
+        "collector_tstamp" : "2013-11-26T00:02:05Z",
+        "dvce_created_tstamp" : "2013-11-26T00:03:57.885Z",
+        "event" : "page_view",
+        "event_id" : "c6ef3124-b53a-4b13-a233-0088f79dcbcb",
+        "txn_id" : 41828,
+        "name_tracker" : "cloudfront-1",
+        "v_tracker" : "js-2.1.0",
+        "v_collector" : "clj-tomcat-0.1.0",
+        "v_etl" : "serde-0.5.2",
+        "user_id" : "jon.doe@email.com",
+        "user_ipaddress" : "92.231.54.234",
+        "user_fingerprint" : "2161814971",
+        "domain_userid" : "bc2e92ec6c204a14",
+        "domain_sessionidx" : 3,
+        "network_userid" : "ecdff4d0-9175-40ac-a8bb-325c49733607",
+        "geo_country" : "US",
+        "geo_region" : "TX",
+        "geo_city" : "New York",
+        "geo_zipcode" : "94109",
+        "geo_latitude" : 37.443604,
+        "geo_longitude" : -122.4124,
+        "geo_region_name" : "Florida",
+        "ip_isp" : "FDN Communications",
+        "ip_organization" : "Bouygues Telecom",
+        "ip_domain" : "nuvox.net",
+        "ip_netspeed" : "Cable/DSL",
+        "page_url" : "http://www.snowplowanalytics.com",
+        "page_title" : "On Analytics",
+        "page_urlscheme" : "http",
+        "page_urlhost" : "www.snowplowanalytics.com",
+        "page_urlport" : 80,
+        "page_urlpath" : "/product/index.html",
+        "page_urlquery" : "id=GTM-DLRG",
+        "page_urlfragment" : "4-conclusion",
+        "contexts_org_schema_web_page_1" : [ {
+          "genre" : "blog",
+          "inLanguage" : "en-US",
+          "datePublished" : "2014-11-06T00:00:00Z",
+          "author" : "Fred Blundun",
+          "breadcrumb" : [ "blog", "releases" ],
+          "keywords" : [ "snowplow", "javascript", "tracker", "event" ]
+        } ],
+        "contexts_org_w3_performance_timing_1" : [ {
+          "navigationStart" : 1415358089861,
+          "unloadEventStart" : 1415358090270,
+          "unloadEventEnd" : 1415358090287,
+          "redirectStart" : 0,
+          "redirectEnd" : 0,
+          "fetchStart" : 1415358089870,
+          "domainLookupStart" : 1415358090102,
+          "domainLookupEnd" : 1415358090102,
+          "connectStart" : 1415358090103,
+          "connectEnd" : 1415358090183,
+          "requestStart" : 1415358090183,
+          "responseStart" : 1415358090265,
+          "responseEnd" : 1415358090265,
+          "domLoading" : 1415358090270,
+          "domInteractive" : 1415358090886,
+          "domContentLoadedEventStart" : 1415358090968,
+          "domContentLoadedEventEnd" : 1415358091309,
+          "domComplete" : 0,
+          "loadEventStart" : 0,
+          "loadEventEnd" : 0
+        } ],
+        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1" : {
+          "schema": {
+            "vendor": "com.snowplowanalytics.snowplow",
+            "name": "link_click",
+            "format": "jsonschema",
+            "version": "1-0-1"
+          },
+          "targetUrl" : "http://www.example.com",
+          "elementClasses" : [ "foreground" ],
+          "elementId" : "exampleLink"
+        },
+        "br_features_pdf" : true,
+        "br_features_flash" : false,
+        "contexts_com_snowplowanalytics_snowplow_ua_parser_context_1": [{
+          "useragentFamily": "IE",
+          "useragentMajor": "7",
+          "useragentMinor": "0",
+          "useragentPatch": null,
+          "useragentVersion": "IE 7.0",
+          "osFamily": "Windows XP",
+          "osMajor": null,
+          "osMinor": null,
+          "osPatch": null,
+          "osPatchMinor": null,
+          "osVersion": "Windows XP",
+          "deviceFamily": "Other"
+        }],
+        "domain_sessionid": "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1",
+        "derived_tstamp": "2013-11-26T00:03:57.886Z",
+        "event_vendor": "com.snowplowanalytics.snowplow",
+        "event_name": "link_click",
+        "event_format": "jsonschema",
+        "event_version": "1-0-0",
+        "event_fingerprint": "e3dbfa9cca0412c3d4052863cefb547f",
+        "true_tstamp": "2013-11-26T00:03:57.886Z"
+      }""")
+
+expected2 = json.loads("""{
+        "geo_location" : "37.443604,-122.4124",
+        "app_id" : "angry-birds",
+        "platform" : "web",
+        "etl_tstamp" : "2017-01-26T00:01:25.292Z",
+        "collector_tstamp" : "2013-11-26T00:02:05Z",
+        "dvce_created_tstamp" : "2013-11-26T00:03:57.885Z",
+        "event" : "page_view",
+        "event_id" : "c6ef3124-b53a-4b13-a233-0088f79dcbcb",
+        "txn_id" : 41828,
+        "name_tracker" : "cloudfront-1",
+        "v_tracker" : "js-2.1.0",
+        "v_collector" : "clj-tomcat-0.1.0",
+        "v_etl" : "serde-0.5.2",
+        "user_id" : "jon.doe@email.com",
+        "user_ipaddress" : "92.231.54.234",
+        "user_fingerprint" : "2161814971",
+        "domain_userid" : "bc2e92ec6c204a14",
+        "domain_sessionidx" : 3,
+        "network_userid" : "ecdff4d0-9175-40ac-a8bb-325c49733607",
+        "geo_country" : "US",
+        "geo_region" : "TX",
+        "geo_city" : "New York",
+        "geo_zipcode" : "94109",
+        "geo_latitude" : 37.443604,
+        "geo_longitude" : -122.4124,
+        "geo_region_name" : "Florida",
+        "ip_isp" : "FDN Communications",
+        "ip_organization" : "Bouygues Telecom",
+        "ip_domain" : "nuvox.net",
+        "ip_netspeed" : "Cable/DSL",
+        "page_url" : "http://www.snowplowanalytics.com",
+        "page_title" : "On Analytics",
+        "page_urlscheme" : "http",
+        "page_urlhost" : "www.snowplowanalytics.com",
+        "page_urlport" : 80,
+        "page_urlpath" : "/product/index.html",
+        "page_urlquery" : "id=GTM-DLRG",
+        "page_urlfragment" : "4-conclusion",
+        "contexts_org_schema_web_page_1" : [ {
+          "schema": {
+            "vendor": "org.schema",
+            "name": "web_page",
+            "format": "jsonschema",
+            "version": "1-0-0"
+          },
+          "genre" : "blog",
+          "inLanguage" : "en-US",
+          "datePublished" : "2014-11-06T00:00:00Z",
+          "author" : "Fred Blundun",
+          "breadcrumb" : [ "blog", "releases" ],
+          "keywords" : [ "snowplow", "javascript", "tracker", "event" ]
+        } ],
+        "contexts_org_w3_performance_timing_1" : [ {
+          "schema": {
+            "vendor": "org.w3",
+            "name": "performance_timing",
+            "format": "jsonschema",
+            "version": "1-0-0"
+          },
+          "navigationStart" : 1415358089861,
+          "unloadEventStart" : 1415358090270,
+          "unloadEventEnd" : 1415358090287,
+          "redirectStart" : 0,
+          "redirectEnd" : 0,
+          "fetchStart" : 1415358089870,
+          "domainLookupStart" : 1415358090102,
+          "domainLookupEnd" : 1415358090102,
+          "connectStart" : 1415358090103,
+          "connectEnd" : 1415358090183,
+          "requestStart" : 1415358090183,
+          "responseStart" : 1415358090265,
+          "responseEnd" : 1415358090265,
+          "domLoading" : 1415358090270,
+          "domInteractive" : 1415358090886,
+          "domContentLoadedEventStart" : 1415358090968,
+          "domContentLoadedEventEnd" : 1415358091309,
+          "domComplete" : 0,
+          "loadEventStart" : 0,
+          "loadEventEnd" : 0
+        } ],
+        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1" : {
+          "targetUrl" : "http://www.example.com",
+          "elementClasses" : [ "foreground" ],
+          "elementId" : "exampleLink"
+        },
+        "br_features_pdf" : true,
+        "br_features_flash" : false,
+        "contexts_com_snowplowanalytics_snowplow_ua_parser_context_1": [{
+          "schema": {
+            "vendor": "com.snowplowanalytics.snowplow",
+            "name": "ua_parser_context",
+            "format": "jsonschema",
+            "version": "1-0-0"
+          },
+          "useragentFamily": "IE",
+          "useragentMajor": "7",
+          "useragentMinor": "0",
+          "useragentPatch": null,
+          "useragentVersion": "IE 7.0",
+          "osFamily": "Windows XP",
+          "osMajor": null,
+          "osMinor": null,
+          "osPatch": null,
+          "osPatchMinor": null,
+          "osVersion": "Windows XP",
+          "deviceFamily": "Other"
+        }],
+        "domain_sessionid": "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1",
+        "derived_tstamp": "2013-11-26T00:03:57.886Z",
+        "event_vendor": "com.snowplowanalytics.snowplow",
+        "event_name": "link_click",
+        "event_format": "jsonschema",
+        "event_version": "1-0-0",
+        "event_fingerprint": "e3dbfa9cca0412c3d4052863cefb547f",
+        "true_tstamp": "2013-11-26T00:03:57.886Z"
+      }""")
+
+def test_transform_with_unstruct_contexts():
+    actual = transform(tsv, add_schema=True)
+    assert(actual == expected)
+
+def test_transform_with_contexts():
+    actual = transform(tsv, add_schema=False, add_schema_contexts=True)
+    assert(actual == expected2)
+

--- a/tests/test_event_transformer_with_schema.py
+++ b/tests/test_event_transformer_with_schema.py
@@ -309,12 +309,6 @@ expected = json.loads("""{
           "loadEventEnd" : 0
         } ],
         "unstruct_event_com_snowplowanalytics_snowplow_link_click_1" : {
-          "schema": {
-            "vendor": "com.snowplowanalytics.snowplow",
-            "name": "link_click",
-            "format": "jsonschema",
-            "version": "1-0-1"
-          },
           "targetUrl" : "http://www.example.com",
           "elementClasses" : [ "foreground" ],
           "elementId" : "exampleLink"
@@ -384,74 +378,88 @@ expected2 = json.loads("""{
         "page_urlpath" : "/product/index.html",
         "page_urlquery" : "id=GTM-DLRG",
         "page_urlfragment" : "4-conclusion",
-        "contexts_org_schema_web_page_1" : [ {
+        "org_schema_web_page_1" : [ {
           "schema": {
             "vendor": "org.schema",
             "name": "web_page",
             "format": "jsonschema",
             "version": "1-0-0"
           },
-          "genre" : "blog",
-          "inLanguage" : "en-US",
-          "datePublished" : "2014-11-06T00:00:00Z",
-          "author" : "Fred Blundun",
-          "breadcrumb" : [ "blog", "releases" ],
-          "keywords" : [ "snowplow", "javascript", "tracker", "event" ]
+          "data": {
+            "genre" : "blog",
+            "inLanguage" : "en-US",
+            "datePublished" : "2014-11-06T00:00:00Z",
+            "author" : "Fred Blundun",
+            "breadcrumb" : [ "blog", "releases" ],
+            "keywords" : [ "snowplow", "javascript", "tracker", "event" ]
+          }
         } ],
-        "contexts_org_w3_performance_timing_1" : [ {
+        "org_w3_performance_timing_1" : [ {
           "schema": {
             "vendor": "org.w3",
             "name": "performance_timing",
             "format": "jsonschema",
             "version": "1-0-0"
           },
-          "navigationStart" : 1415358089861,
-          "unloadEventStart" : 1415358090270,
-          "unloadEventEnd" : 1415358090287,
-          "redirectStart" : 0,
-          "redirectEnd" : 0,
-          "fetchStart" : 1415358089870,
-          "domainLookupStart" : 1415358090102,
-          "domainLookupEnd" : 1415358090102,
-          "connectStart" : 1415358090103,
-          "connectEnd" : 1415358090183,
-          "requestStart" : 1415358090183,
-          "responseStart" : 1415358090265,
-          "responseEnd" : 1415358090265,
-          "domLoading" : 1415358090270,
-          "domInteractive" : 1415358090886,
-          "domContentLoadedEventStart" : 1415358090968,
-          "domContentLoadedEventEnd" : 1415358091309,
-          "domComplete" : 0,
-          "loadEventStart" : 0,
-          "loadEventEnd" : 0
+          "data": {
+            "navigationStart" : 1415358089861,
+            "unloadEventStart" : 1415358090270,
+            "unloadEventEnd" : 1415358090287,
+            "redirectStart" : 0,
+            "redirectEnd" : 0,
+            "fetchStart" : 1415358089870,
+            "domainLookupStart" : 1415358090102,
+            "domainLookupEnd" : 1415358090102,
+            "connectStart" : 1415358090103,
+            "connectEnd" : 1415358090183,
+            "requestStart" : 1415358090183,
+            "responseStart" : 1415358090265,
+            "responseEnd" : 1415358090265,
+            "domLoading" : 1415358090270,
+            "domInteractive" : 1415358090886,
+            "domContentLoadedEventStart" : 1415358090968,
+            "domContentLoadedEventEnd" : 1415358091309,
+            "domComplete" : 0,
+            "loadEventStart" : 0,
+            "loadEventEnd" : 0
+          }
         } ],
-        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1" : {
-          "targetUrl" : "http://www.example.com",
-          "elementClasses" : [ "foreground" ],
-          "elementId" : "exampleLink"
+        "com_snowplowanalytics_snowplow_link_click_1" : {
+          "schema": {
+            "vendor": "com.snowplowanalytics.snowplow",
+            "name": "link_click",
+            "format": "jsonschema",
+            "version": "1-0-1"
+          },
+          "data": {
+            "targetUrl" : "http://www.example.com",
+            "elementClasses" : [ "foreground" ],
+            "elementId" : "exampleLink"
+          }
         },
         "br_features_pdf" : true,
         "br_features_flash" : false,
-        "contexts_com_snowplowanalytics_snowplow_ua_parser_context_1": [{
+        "com_snowplowanalytics_snowplow_ua_parser_context_1": [{
           "schema": {
             "vendor": "com.snowplowanalytics.snowplow",
             "name": "ua_parser_context",
             "format": "jsonschema",
             "version": "1-0-0"
           },
-          "useragentFamily": "IE",
-          "useragentMajor": "7",
-          "useragentMinor": "0",
-          "useragentPatch": null,
-          "useragentVersion": "IE 7.0",
-          "osFamily": "Windows XP",
-          "osMajor": null,
-          "osMinor": null,
-          "osPatch": null,
-          "osPatchMinor": null,
-          "osVersion": "Windows XP",
-          "deviceFamily": "Other"
+          "data": {
+            "useragentFamily": "IE",
+            "useragentMajor": "7",
+            "useragentMinor": "0",
+            "useragentPatch": null,
+            "useragentVersion": "IE 7.0",
+            "osFamily": "Windows XP",
+            "osMajor": null,
+            "osMinor": null,
+            "osPatch": null,
+            "osPatchMinor": null,
+            "osVersion": "Windows XP",
+            "deviceFamily": "Other"
+          }
         }],
         "domain_sessionid": "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1",
         "derived_tstamp": "2013-11-26T00:03:57.886Z",
@@ -463,11 +471,11 @@ expected2 = json.loads("""{
         "true_tstamp": "2013-11-26T00:03:57.886Z"
       }""")
 
-def test_transform_with_unstruct_contexts():
-    actual = transform(tsv, add_schema=True)
+def test_transform_with_elasticsearch_format():
+    actual = transform(tsv, shred_format='elasticsearch')
     assert(actual == expected)
 
-def test_transform_with_contexts():
-    actual = transform(tsv, add_schema=False, add_schema_contexts=True)
+def test_transform_with_redshift_format():
+    actual = transform(tsv, shred_format='redshift')
     assert(actual == expected2)
 

--- a/tests/test_json_shredding.py
+++ b/tests/test_json_shredding.py
@@ -16,7 +16,7 @@
 
 from snowplow_analytics_sdk.json_shredder import parse_contexts, parse_unstruct
 
-def test_parse_contexts_with_schema():
+def test_parse_contexts_redshift():
     json_input = """{
       "data": [
         {
@@ -42,43 +42,49 @@ def test_parse_contexts_with_schema():
     }"""
 
     expected = [
-        ('contexts_com_acme_unduplicated_1', [{
-                        'unique': True,
-                        'schema':
-                            {
-                                'version': '1-0-0',
-                                'vendor': 'com.acme',
-                                'name': 'unduplicated',
-                                'format': 'jsonschema'
-                            }
+            ('com_acme_unduplicated_1', [{
+                'schema':
+                    {
+                        'version': '1-0-0',
+                        'vendor': 'com.acme',
+                        'name': 'unduplicated',
+                        'format': 'jsonschema'
+                    },
+                'data': {
+                    'unique': True
+                },
                         }]),
-        ('contexts_com_acme_duplicated_1', [
+        ('com_acme_duplicated_1', [
             {
-                'value': 1,
                 'schema':
                     {
                         'version': '1-0-0',
                         'vendor': 'com.acme',
                         'name': 'duplicated',
                         'format': 'jsonschema'
-                    }
+                    },
+                'data': {
+                    'value': 1
+                }
             },
             {
-                'value': 2,
-                'schema': 
+                'schema':
                     {
                         'version': '1-0-0',
                         'vendor': 'com.acme',
                         'name': 'duplicated',
                         'format': 'jsonschema'
-                    }
+                    },
+                'data': {
+                    'value': 2
+                },
             }
         ])
     ]
-    result = parse_contexts(json_input, include_schema=True)
+    result = parse_contexts(json_input, shred_format='redshift')
     assert(sorted(result) == sorted(expected))
 
-def test_parse_contexts_without_schema():
+def test_parse_contexts_elasticsearch():
     json_input = """{
       "data": [
         {
@@ -107,10 +113,10 @@ def test_parse_contexts_without_schema():
         ('contexts_com_acme_unduplicated_1', [{'unique': True}]),
         ('contexts_com_acme_duplicated_1', [{'value': 1}, {'value': 2}])
     ]
-    result = parse_contexts(json_input, include_schema=False)
+    result = parse_contexts(json_input, shred_format='elasticsearch')
     assert(sorted(result) == sorted(expected))
 
-def test_parse_unstruct_with_schema():
+def test_parse_unstruct_redshift():
     json_input = """{
       "data": {
         "data": {
@@ -122,22 +128,24 @@ def test_parse_unstruct_with_schema():
     }"""
     expected = [
       (
-        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1", {
+        "com_snowplowanalytics_snowplow_link_click_1", {
           "schema": {
             "vendor": "com.snowplowanalytics.snowplow",
             "name": "link_click",
             "format": "jsonschema",
             "version": "1-0-1"
           },
-          "key": "value"
+          "data": {
+            "key": "value"
+          }
         }
       )
     ]
 
-    result = parse_unstruct(json_input, include_schema=True)
+    result = parse_unstruct(json_input, shred_format='redshift')
     assert(result == expected)
 
-def test_parse_unstruct_without_schema():
+def test_parse_unstruct_elasticsearch():
     json_input = """{
       "data": {
         "data": {
@@ -155,5 +163,5 @@ def test_parse_unstruct_without_schema():
       )
     ]
 
-    result = parse_unstruct(json_input)
+    result = parse_unstruct(json_input, shred_format='elasticsearch')
     assert(result == expected)

--- a/tests/test_json_shredding.py
+++ b/tests/test_json_shredding.py
@@ -16,6 +16,7 @@
 
 from snowplow_analytics_sdk.json_shredder import parse_contexts, parse_unstruct
 
+
 def test_parse_contexts_redshift():
     json_input = """{
       "data": [
@@ -42,39 +43,39 @@ def test_parse_contexts_redshift():
     }"""
 
     expected = [
-            ('com_acme_unduplicated_1', [{
-                'schema':
-                    {
-                        'version': '1-0-0',
-                        'vendor': 'com.acme',
-                        'name': 'unduplicated',
+        ('com_acme_unduplicated_1', [{
+            'schema':
+            {
+                'version': '1-0-0',
+                'vendor': 'com.acme',
+                'name': 'unduplicated',
                         'format': 'jsonschema'
-                    },
+            },
                 'data': {
                     'unique': True
-                },
-                        }]),
+            },
+        }]),
         ('com_acme_duplicated_1', [
             {
                 'schema':
-                    {
-                        'version': '1-0-0',
-                        'vendor': 'com.acme',
-                        'name': 'duplicated',
-                        'format': 'jsonschema'
-                    },
+                {
+                    'version': '1-0-0',
+                    'vendor': 'com.acme',
+                    'name': 'duplicated',
+                    'format': 'jsonschema'
+                },
                 'data': {
                     'value': 1
                 }
             },
             {
                 'schema':
-                    {
-                        'version': '1-0-0',
-                        'vendor': 'com.acme',
-                        'name': 'duplicated',
-                        'format': 'jsonschema'
-                    },
+                {
+                    'version': '1-0-0',
+                    'vendor': 'com.acme',
+                    'name': 'duplicated',
+                    'format': 'jsonschema'
+                },
                 'data': {
                     'value': 2
                 },
@@ -83,6 +84,7 @@ def test_parse_contexts_redshift():
     ]
     result = parse_contexts(json_input, shred_format='redshift')
     assert(sorted(result) == sorted(expected))
+
 
 def test_parse_contexts_elasticsearch():
     json_input = """{
@@ -116,6 +118,7 @@ def test_parse_contexts_elasticsearch():
     result = parse_contexts(json_input, shred_format='elasticsearch')
     assert(sorted(result) == sorted(expected))
 
+
 def test_parse_unstruct_redshift():
     json_input = """{
       "data": {
@@ -127,23 +130,24 @@ def test_parse_unstruct_redshift():
       "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0"
     }"""
     expected = [
-      (
-        "com_snowplowanalytics_snowplow_link_click_1", {
-          "schema": {
-            "vendor": "com.snowplowanalytics.snowplow",
-            "name": "link_click",
-            "format": "jsonschema",
-            "version": "1-0-1"
-          },
-          "data": {
-            "key": "value"
-          }
-        }
-      )
+        (
+            "com_snowplowanalytics_snowplow_link_click_1", {
+                "schema": {
+                    "vendor": "com.snowplowanalytics.snowplow",
+                    "name": "link_click",
+                    "format": "jsonschema",
+                    "version": "1-0-1"
+                },
+                "data": {
+                    "key": "value"
+                }
+            }
+        )
     ]
 
     result = parse_unstruct(json_input, shred_format='redshift')
     assert(result == expected)
+
 
 def test_parse_unstruct_elasticsearch():
     json_input = """{
@@ -156,11 +160,11 @@ def test_parse_unstruct_elasticsearch():
       "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0"
     }"""
     expected = [
-      (
-        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1", {
-          "key": "value"
-        }
-      )
+        (
+            "unstruct_event_com_snowplowanalytics_snowplow_link_click_1", {
+                "key": "value"
+            }
+        )
     ]
 
     result = parse_unstruct(json_input, shred_format='elasticsearch')

--- a/tests/test_json_shredding.py
+++ b/tests/test_json_shredding.py
@@ -1,0 +1,159 @@
+"""
+    Copyright (c) 2017 Snowplow Analytics Ltd. All rights reserved.
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+    Authors: Mike Robins
+    Copyright: Copyright (c) 2017 Snowplow Analytics Ltd
+    License: Apache License Version 2.0
+"""
+
+from snowplow_analytics_sdk.json_shredder import parse_contexts, parse_unstruct
+
+def test_parse_contexts_with_schema():
+    json_input = """{
+      "data": [
+        {
+          "data": {
+            "unique": true
+          },
+          "schema": "iglu:com.acme/unduplicated/jsonschema/1-0-0"
+        },
+        {
+          "data": {
+            "value": 1
+          },
+          "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0"
+        },
+        {
+          "data": {
+            "value": 2
+          },
+          "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0"
+        }
+      ],
+      "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0"
+    }"""
+
+    expected = [
+        ('contexts_com_acme_unduplicated_1', [{
+                        'unique': True,
+                        'schema':
+                            {
+                                'version': '1-0-0',
+                                'vendor': 'com.acme',
+                                'name': 'unduplicated',
+                                'format': 'jsonschema'
+                            }
+                        }]),
+        ('contexts_com_acme_duplicated_1', [
+            {
+                'value': 1,
+                'schema':
+                    {
+                        'version': '1-0-0',
+                        'vendor': 'com.acme',
+                        'name': 'duplicated',
+                        'format': 'jsonschema'
+                    }
+            },
+            {
+                'value': 2,
+                'schema': 
+                    {
+                        'version': '1-0-0',
+                        'vendor': 'com.acme',
+                        'name': 'duplicated',
+                        'format': 'jsonschema'
+                    }
+            }
+        ])
+    ]
+    result = parse_contexts(json_input, include_schema=True)
+    assert(sorted(result) == sorted(expected))
+
+def test_parse_contexts_without_schema():
+    json_input = """{
+      "data": [
+        {
+          "data": {
+            "unique": true
+          },
+          "schema": "iglu:com.acme/unduplicated/jsonschema/1-0-0"
+        },
+        {
+          "data": {
+            "value": 1
+          },
+          "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0"
+        },
+        {
+          "data": {
+            "value": 2
+          },
+          "schema": "iglu:com.acme/duplicated/jsonschema/1-0-0"
+        }
+      ],
+      "schema": "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0"
+    }"""
+
+    expected = [
+        ('contexts_com_acme_unduplicated_1', [{'unique': True}]),
+        ('contexts_com_acme_duplicated_1', [{'value': 1}, {'value': 2}])
+    ]
+    result = parse_contexts(json_input, include_schema=False)
+    assert(sorted(result) == sorted(expected))
+
+def test_parse_unstruct_with_schema():
+    json_input = """{
+      "data": {
+        "data": {
+          "key": "value"
+        },
+        "schema": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1"
+      },
+      "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0"
+    }"""
+    expected = [
+      (
+        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1", {
+          "schema": {
+            "vendor": "com.snowplowanalytics.snowplow",
+            "name": "link_click",
+            "format": "jsonschema",
+            "version": "1-0-1"
+          },
+          "key": "value"
+        }
+      )
+    ]
+
+    result = parse_unstruct(json_input, include_schema=True)
+    assert(result == expected)
+
+def test_parse_unstruct_without_schema():
+    json_input = """{
+      "data": {
+        "data": {
+          "key": "value"
+        },
+        "schema": "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1"
+      },
+      "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0"
+    }"""
+    expected = [
+      (
+        "unstruct_event_com_snowplowanalytics_snowplow_link_click_1", {
+          "key": "value"
+        }
+      )
+    ]
+
+    result = parse_unstruct(json_input)
+    assert(result == expected)

--- a/tests/test_schema_parsing.py
+++ b/tests/test_schema_parsing.py
@@ -1,0 +1,56 @@
+"""
+    Copyright (c) 2017 Snowplow Analytics Ltd. All rights reserved.
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+    Authors: Mike Robins
+    Copyright: Copyright (c) 2017 Snowplow Analytics Ltd
+    License: Apache License Version 2.0
+"""
+
+from snowplow_analytics_sdk.json_shredder import parse_schema, fix_schema
+
+
+def test_schema_parse():
+    input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
+    expected_vendor = "com.snowplowanalytics.snowplow"
+    expected_name = "web_page"
+    expected_format = "jsonschema"
+    expected_version = "1-0-0"
+
+    vendor, name, format, version = parse_schema(input_schema, underscore_vendor=False)
+    assert(vendor == expected_vendor)
+    assert(name == expected_name)
+    assert(format == expected_format)
+    assert(version == expected_version)
+
+def test_schema_parse_underscore_vendor():
+    input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
+    expected_vendor = "com_snowplowanalytics_snowplow"
+    expected_name = "web_page"
+    expected_format = "jsonschema"
+    expected_version = "1-0-0"
+
+    vendor, name, format, version = parse_schema(input_schema, underscore_vendor=True)
+    assert(vendor == expected_vendor)
+    assert(name == expected_name)
+    assert(format == expected_format)
+    assert(version == expected_version)
+
+def test_fix_schema_elasticsearch_contexts():
+    input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
+    expected_string = "contexts_com_snowplowanalytics_snowplow_web_page_1"
+    actual_string = fix_schema("contexts", input_schema)
+    assert(actual_string == expected_string)
+
+def test_fix_schema_elasticsearch_unstruct():
+    input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
+    expected_string = "unstruct_event_com_snowplowanalytics_snowplow_web_page_1"
+    actual_string = fix_schema("unstruct_event", input_schema)
+    assert(actual_string == expected_string)

--- a/tests/test_schema_parsing.py
+++ b/tests/test_schema_parsing.py
@@ -30,6 +30,7 @@ def test_schema_parse():
     assert(format == expected_format)
     assert(version == expected_version)
 
+
 def test_schema_parse_underscore_vendor():
     input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
     expected_vendor = "com_snowplowanalytics_snowplow"
@@ -43,11 +44,13 @@ def test_schema_parse_underscore_vendor():
     assert(format == expected_format)
     assert(version == expected_version)
 
+
 def test_fix_schema_elasticsearch_contexts():
     input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"
     expected_string = "contexts_com_snowplowanalytics_snowplow_web_page_1"
     actual_string = fix_schema("contexts", input_schema)
     assert(actual_string == expected_string)
+
 
 def test_fix_schema_elasticsearch_unstruct():
     input_schema = "iglu:com.snowplowanalytics.snowplow/WebPage/jsonschema/1-0-0"


### PR DESCRIPTION
This is a WIP but I'd like to get some comments/thoughts on it based on #31 

This introduces the concept of the 'redshift' (or a more appropriate name) shredding which more closely follows what is shredded into Redshift in terms of the table design. This differs from the current implementation which is more consistent with how data is sunk into Elasticsearch.

The shredding format introduced below makes the following changes:
- Removes the 'contexts' and 'unstruct_event' prefix for the JSON objects
- Retains backwards compatibility by passing `shred_format='elasticsearch'` by default
- Adds a nested schema object to contexts/unstruct_events which contains vendor, name, format and version
- Adds a nested data object which contains the contents of the payload
- Adds additional tests to clarify the behaviour of both shredding formats in partial and complete payloads

As a sidenote the code likely needs some refactoring/reformatting and the existing docstrings for the methods have not been updated to reflect the new behaviour.