### PR TITLE
Add option to preserve empty fields in result JSON

### DIFF
--- a/snowplow_analytics_sdk/event_transformer.py
+++ b/snowplow_analytics_sdk/event_transformer.py
@@ -189,14 +189,14 @@ ENRICHED_EVENT_FIELD_TYPES = (
 )
 
 
-def transform(line, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True):
+def transform(line, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, drop_empty_fields=True):
     """
     Convert a Snowplow enriched event TSV into a JSON
     """
-    return jsonify_good_event(line.split('\t'), known_fields, add_geolocation_data)
+    return jsonify_good_event(line.split('\t'), known_fields, add_geolocation_data, drop_empty_fields)
 
 
-def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True):
+def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolocation_data=True, drop_empty_fields=True):
     """
     Convert a Snowplow enriched event in the form of an array of fields into a JSON
     """
@@ -224,6 +224,9 @@ def jsonify_good_event(event, known_fields=ENRICHED_EVENT_FIELD_TYPES, add_geolo
                         event[i],
                         repr(e)
                     )]
+            else:
+                if not drop_empty_fields:
+                    output[key] = None
         if errors:
             raise SnowplowEventTransformationException(errors)
         else:

--- a/tests/test_event_transformer.py
+++ b/tests/test_event_transformer.py
@@ -340,9 +340,23 @@ expected = json.loads("""{
       }""")
 
 
+def _get_expected_with_empty_fields():
+    result = expected.copy()
+    exclude = ('derived_contexts', 'contexts', 'unstruct_event')
+    for key, value in full_event:
+        if key not in exclude and key not in result:
+            result[key] = None
+    return result
+
+
 def test_transform():
     actual = transform(tsv)
     assert(actual == expected)
+
+
+def test_transform_keep_empty_fields():
+    actual = transform(tsv, drop_empty_fields=False)
+    assert(actual == _get_expected_with_empty_fields())
 
 
 def test_wrong_tsv_length():


### PR DESCRIPTION
By default, fields with empty string values are omitted from the result JSON. The Snowplow Java SDK preserves such fields by assigning them null. This change adds an option to enable the same behavior for compatibility.